### PR TITLE
Add LinkedIn group reply functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,13 @@ want to change the topic of your LinkedIn post, you'll need to modify the Agents
 ```shell
 python3 main.py
 ```
+
+### Environment variables for group replies
+
+To generate replies to posts in your LinkedIn groups, set the `LINKEDIN_GROUP_URLS`
+environment variable with a comma separated list of group URLs.
+Example:
+
+```bash
+export LINKEDIN_GROUP_URLS="https://www.linkedin.com/groups/1234/,https://www.linkedin.com/groups/5678/"
+```

--- a/agents.py
+++ b/agents.py
@@ -7,7 +7,10 @@ from dotenv import load_dotenv
 from langchain_mistralai import ChatMistralAI
 from langchain_openai import ChatOpenAI
 
-from tools import scrape_linkedin_posts_tool
+from tools import (
+    scrape_linkedin_posts_tool,
+    scrape_linkedin_group_posts_tool,
+)
 
 load_dotenv()
 
@@ -63,4 +66,35 @@ doppelganger_agent = Agent(
     verbose=True,
     allow_delegation=False,
     llm=openai_llm
+)
+
+
+group_scraper_agent = Agent(
+    role="LinkedIn Group Scraper",
+    goal="Scrape the latest posts from the LinkedIn groups provided",
+    tools=[scrape_linkedin_group_posts_tool],
+    backstory=dedent(
+        """
+        You are skilled at navigating LinkedIn groups and collecting recent posts
+        for analysis.
+        """
+    ),
+    verbose=True,
+    allow_delegation=False,
+    llm=openai_llm,
+)
+
+group_reply_agent = Agent(
+    role="LinkedIn Group Reply Creator",
+    goal="Write concise replies to posts in LinkedIn groups.",
+    tools=[],
+    backstory=dedent(
+        """
+        You craft short professional replies that encourage discussion while
+        keeping a friendly tone.
+        """
+    ),
+    verbose=True,
+    allow_delegation=False,
+    llm=openai_llm,
 )

--- a/main.py
+++ b/main.py
@@ -1,8 +1,20 @@
 from crewai import Crew
 from dotenv import load_dotenv
 
-from agents import linkedin_scraper_agent, web_researcher_agent, doppelganger_agent
-from tasks import scrape_linkedin_task, web_research_task, create_linkedin_post_task
+from agents import (
+    linkedin_scraper_agent,
+    web_researcher_agent,
+    doppelganger_agent,
+    group_scraper_agent,
+    group_reply_agent,
+)
+from tasks import (
+    scrape_linkedin_task,
+    web_research_task,
+    create_linkedin_post_task,
+    scrape_group_posts_task,
+    generate_group_replies_task,
+)
 
 load_dotenv()
 
@@ -11,12 +23,16 @@ crew = Crew(
     agents=[
         linkedin_scraper_agent,
         web_researcher_agent,
-        doppelganger_agent
+        doppelganger_agent,
+        group_scraper_agent,
+        group_reply_agent,
     ],
     tasks=[
         scrape_linkedin_task,
         web_research_task,
-        create_linkedin_post_task
+        create_linkedin_post_task,
+        scrape_group_posts_task,
+        generate_group_replies_task,
     ]
 )
 

--- a/tasks.py
+++ b/tasks.py
@@ -1,6 +1,12 @@
 from crewai import Task
 from textwrap import dedent
-from agents import linkedin_scraper_agent, web_researcher_agent, doppelganger_agent
+from agents import (
+    linkedin_scraper_agent,
+    web_researcher_agent,
+    doppelganger_agent,
+    group_scraper_agent,
+    group_reply_agent,
+)
 
 
 scrape_linkedin_task = Task(
@@ -32,3 +38,22 @@ create_linkedin_post_task = Task(
 )
 
 create_linkedin_post_task.context = [scrape_linkedin_task, web_research_task]
+
+
+scrape_group_posts_task = Task(
+    description=dedent("Scrape the latest posts from the LinkedIn groups"),
+    expected_output=dedent("A dictionary of groups with a list of recent posts"),
+    agent=group_scraper_agent,
+)
+
+generate_group_replies_task = Task(
+    description=dedent(
+        "Generate short professional replies to the scraped group posts"
+    ),
+    expected_output=dedent(
+        "A list of suggested replies for each scraped post"
+    ),
+    agent=group_reply_agent,
+)
+
+generate_group_replies_task.context = [scrape_group_posts_task]

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,1 +1,6 @@
-from .linkedin import scrape_linkedin_posts_tool, scrape_linkedin_posts_fn
+from .linkedin import (
+    scrape_linkedin_posts_tool,
+    scrape_linkedin_posts_fn,
+    scrape_linkedin_group_posts_tool,
+    scrape_linkedin_group_posts_fn,
+)

--- a/tools/linkedin.py
+++ b/tools/linkedin.py
@@ -54,3 +54,45 @@ def scrape_linkedin_posts_tool() -> str:
     A tool that can be used to scrape LinkedIn posts
     """
     return scrape_linkedin_posts_fn()
+
+
+def scrape_linkedin_group_posts_fn() -> str:
+    """Scrape latest posts from the groups provided in ``LINKEDIN_GROUP_URLS``."""
+    linkedin_username = os.environ.get("LINKEDIN_EMAIL")
+    linkedin_password = os.environ.get("LINKEDIN_PASSWORD")
+    group_urls = os.environ.get("LINKEDIN_GROUP_URLS")
+
+    if not (linkedin_username and linkedin_password):
+        raise LinkedinToolException()
+
+    if not group_urls:
+        raise Exception("You need to set the LINKEDIN_GROUP_URLS env variable")
+
+    browser = webdriver.Chrome()
+    browser.get("https://www.linkedin.com/login")
+
+    username_input = browser.find_element("id", "username")
+    password_input = browser.find_element("id", "password")
+    username_input.send_keys(linkedin_username)
+    password_input.send_keys(linkedin_password)
+    password_input.send_keys(Keys.RETURN)
+
+    time.sleep(5)
+
+    posts_by_group = {}
+    for url in [url.strip() for url in group_urls.split(",") if url.strip()]:
+        browser.get(url)
+        for _ in range(2):
+            browser.execute_script("window.scrollTo(0, document.body.scrollHeight);")
+            time.sleep(2)
+        posts = get_linkedin_posts(browser.page_source)
+        posts_by_group[url] = posts[:2]
+
+    browser.quit()
+    return str(posts_by_group)
+
+
+@tool("ScrapeLinkedinGroupPosts")
+def scrape_linkedin_group_posts_tool() -> str:
+    """A tool that scrapes LinkedIn groups for recent posts."""
+    return scrape_linkedin_group_posts_fn()


### PR DESCRIPTION
## Summary
- add scraping for LinkedIn group posts
- expose new tools for group scraping
- create agents and tasks for replying to group posts
- extend main workflow to include group replies
- document new `LINKEDIN_GROUP_URLS` env variable

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'crewai')*

------
https://chatgpt.com/codex/tasks/task_b_6856ac5f00288330b4213706d5dc4b6e