### PR TITLE
Add JSON output for multiple reframed LinkedIn posts

### DIFF
--- a/reframe_latest_post.py
+++ b/reframe_latest_post.py
@@ -3,7 +3,12 @@ from dotenv import load_dotenv
 from langchain_openai import ChatOpenAI
 from langchain.prompts import ChatPromptTemplate
 
-from tools import scrape_linkedin_posts_fn, classify_post
+import json
+from tools import (
+    scrape_linkedin_posts_fn,
+    scrape_linkedin_posts_with_urls_fn,
+    classify_post,
+)
 
 load_dotenv()
 
@@ -14,13 +19,9 @@ if not influencer_profile or not target_profile:
     raise SystemExit("INFLUENCER_PROFILE_NAME and TARGET_PROFILE_NAME must be set")
 
 influencer_posts = scrape_linkedin_posts_fn(influencer_profile)
-target_posts = scrape_linkedin_posts_fn(target_profile)
+target_posts = scrape_linkedin_posts_with_urls_fn(target_profile)
 
-latest_post = target_posts[0] if target_posts else ""
 style_examples = "\n\n".join(influencer_posts)
-
-post_type = classify_post(latest_post)
-print(f"Post type: {post_type}")
 
 llm = ChatOpenAI(api_key=os.environ.get("OPENAI_API_KEY"), model="gpt-3.5-turbo-0125")
 
@@ -37,7 +38,18 @@ prompt = ChatPromptTemplate.from_messages([
 ])
 chain = prompt | llm
 
-result = chain.invoke({"post": latest_post, "style": style_examples})
+outputs = []
 
-print(result.content)
+for entry in target_posts:
+    post_text = entry.get("post", "")
+    url = entry.get("url", "")
+    post_type = classify_post(post_text)
+    print(f"Post type: {post_type}")
+    result = chain.invoke({"post": post_text, "style": style_examples})
+    outputs.append({"post": post_text, "url": url, "response": result.content})
+
+with open("output.json", "w") as f:
+    json.dump(outputs, f, indent=2)
+
+print(json.dumps(outputs, indent=2))
 

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -2,6 +2,7 @@ from .linkedin import (
     scrape_influencer_posts_tool,
     scrape_target_posts_tool,
     scrape_linkedin_posts_fn,
+    scrape_linkedin_posts_with_urls_fn,
     
 )
 from .utils import classify_post, is_personal_post

--- a/tools/linkedin.py
+++ b/tools/linkedin.py
@@ -5,7 +5,7 @@ from crewai.tools import tool
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 
-from tools.utils import get_linkedin_posts
+from tools.utils import get_linkedin_posts, get_linkedin_posts_with_urls
 
 
 class LinkedinToolException(Exception):
@@ -49,6 +49,37 @@ def scrape_linkedin_posts_fn(profile_name: str) -> list[str]:
     browser.quit()
 
     # We'll just return 2 of the latest posts, since it should be enough for the LLM to get the overall style
+    return posts[:2]
+
+
+def scrape_linkedin_posts_with_urls_fn(profile_name: str) -> list[dict]:
+    """Scrape posts and their URLs from a LinkedIn profile."""
+    linkedin_username = os.environ.get("LINKEDIN_EMAIL")
+    linkedin_password = os.environ.get("LINKEDIN_PASSWORD")
+
+    if not (linkedin_username and linkedin_password):
+        raise LinkedinToolException()
+
+    browser = webdriver.Chrome()
+    browser.get("https://www.linkedin.com/login")
+
+    username_input = browser.find_element("id", "username")
+    password_input = browser.find_element("id", "password")
+    username_input.send_keys(linkedin_username)
+    password_input.send_keys(linkedin_password)
+    password_input.send_keys(Keys.RETURN)
+
+    time.sleep(20)
+
+    browser.get(f"https://www.linkedin.com/in/{profile_name}/recent-activity/all/")
+
+    for _ in range(2):
+        browser.execute_script("window.scrollTo(0, document.body.scrollHeight);")
+        time.sleep(2)
+
+    posts = get_linkedin_posts_with_urls(browser.page_source)
+    browser.quit()
+
     return posts[:2]
 
 

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -50,6 +50,20 @@ def get_linkedin_posts(page_source: str):
     return posts
 
 
+def get_linkedin_posts_with_urls(page_source: str):
+    """Return LinkedIn posts along with their URLs."""
+    containers = parse_html_content(page_source)
+    posts = []
+
+    for container in containers:
+        post_content = get_post_content(container, "div", {"class": "update-components-text"})
+        urn = container.get("data-urn", "")
+        url = f"https://www.linkedin.com/feed/update/{urn}/" if urn else ""
+        posts.append({"post": post_content, "url": url})
+
+    return posts
+
+
 def is_personal_post(post: str) -> bool:
     """Return ``True`` if the text appears to reference personal life events."""
     if not post:


### PR DESCRIPTION
## Summary
- extend LinkedIn scraping utilities to capture URLs
- expose new scraping function to callers
- reframe all scraped posts and write results to `output.json`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685802b9b4a08330abd25f76833437df